### PR TITLE
Added the Plastic Style

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ Below are several examples showcasing different ways to generate progress bars.
 
 ## Styles
 
-We currently have `flat` (default) and `square` styles:
+We currently have `flat` (default), `square` and `plastic` styles:
 
 | Example Preview                                                                 | URL                                                                                      |
 |---------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
 | ![Progress](https://progress-bar.xyz/100/?style=flat)                           | [https://progress-bar.xyz/100/?style=flat](https://progress-bar.xyz/100/?style=flat)     |
 | ![Progress](https://progress-bar.xyz/100/?style=square)                         | [https://progress-bar.xyz/100/?style=square](https://progress-bar.xyz/100/?style=square) |   
+| ![Progress](https://progress-bar.xyz/100/?style=plastic)                         | [https://progress-bar.xyz/100/?style=plastic](https://progress-bar.xyz/100/?style=plastic) |   
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -72,7 +72,7 @@ def get_style_fields(style):
             "show_shadow": False,
         },
         "plastic": {
-            "border_radius": 4,
+            "border_radius": 5,
             "title_color": "555",
             "progress_color": "91bc13",  # Greenish color for a plastic look
             "progress_background": "ECEFF1",  # Light background to enhance contrast

--- a/app.py
+++ b/app.py
@@ -161,4 +161,4 @@ def redirect_to_github():
     return redirect("https://github.com/guibranco/progressbar", code=302)
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run()

--- a/app.py
+++ b/app.py
@@ -72,7 +72,12 @@ def get_style_fields(style):
             "show_shadow": False,
         },
         "plastic": {
-            #
+            "border_radius": 4,
+            "title_color": "555",
+            "progress_color": "91bc13",  # Greenish color for a plastic look
+            "progress_background": "ECEFF1",  # Light background to enhance contrast
+            "show_shadow": True,
+            "gloss": True,  # Adding a gloss effect for plastic
         },
         "for-the-badge": {
             #
@@ -156,4 +161,4 @@ def redirect_to_github():
     return redirect("https://github.com/guibranco/progressbar", code=302)
 
 if __name__ == "__main__":
-    app.run()
+    app.run(debug=True)

--- a/templates/progress.svg
+++ b/templates/progress.svg
@@ -1,13 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="{{ title_width + progress_width }}" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid">
+  <!-- ClipPath to constrain the shadow within the progress bar -->
+  <defs>
+    <clipPath id="progress_clip">
+      <rect rx="{{ border_radius }}" x="{{ title_width }}" width="{{ progress_width }}" height="20"/>
+    </clipPath>
+  </defs>
+
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
 
+  <!-- Main background with consistent border radius -->
   <rect rx="{{ border_radius }}" x="0" width="{{ title_width + progress_width }}" height="20" fill="#{{ title_color }}"/>
+  
+  <!-- Progress bar background with the same border radius -->
   <rect rx="{{ border_radius }}" x="{{ title_width }}" width="{{ progress_width }}" height="20" fill="#{{ progress_background }}" />
+  
+  <!-- Progress fill with the same border radius to avoid sharp corners -->
   <rect rx="{{ border_radius }}" x="{{ title_width }}" width="{{ [progress/scale, 1] | min * progress_width | int }}" height="20" fill="#{{ progress_color }}" />
+  
   {% if title %}
     <path fill="#{{ progress_color }}" d="M{{ title_width }} 0h4v20h-4z" />
   {% endif %}
@@ -35,14 +48,14 @@
       <stop offset="0%" stop-color="rgba(255,255,255,0.85)" />
       <stop offset="60%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
-    <rect x="{{ title_width }}" y="0" width="{{ progress_width }}" height="12" fill="url(#progress_gloss)" clip-path="url(#clip)" />
+    <rect x="{{ title_width }}" y="0" width="{{ progress_width }}" height="12" fill="url(#progress_gloss)" clip-path="url(#progress_clip)" />
 
     <!-- Shadow for progress bar -->
     <linearGradient id="progress_shadow" x1="0" y1="0.6" x2="0" y2="1">
       <stop offset="0%" stop-color="rgba(0,0,0,0)" />
       <stop offset="100%" stop-color="rgba(0,0,0,0.2)" />
     </linearGradient>
-    <rect x="{{ title_width }}" y="9" width="{{ progress_width }}" height="11" fill="url(#progress_shadow)" clip-path="url(#clip)" />
+    <rect x="{{ title_width }}" y="9" width="{{ progress_width - 1 }}" height="11" fill="url(#progress_shadow)" clip-path="url(#progress_clip)" />
   {% endif %}
 
   {% if title %}

--- a/templates/progress.svg
+++ b/templates/progress.svg
@@ -11,36 +11,38 @@
   {% if title %}
     <path fill="#{{ progress_color }}" d="M{{ title_width }} 0h4v20h-4z" />
   {% endif %}
-  <rect rx="{{ border_radius }}" width="{{ title_width + progress_width }}" height="20" fill="url(#a)" />
+  
+  <!-- Apply the clipping path to keep everything inside the border radius -->
+  <rect rx="{{ border_radius }}" width="{{ title_width + progress_width }}" height="20" fill="url(#a)" clip-path="url(#clip)" />
 
   {% if gloss %}
     <!-- Gloss for title -->
-    <linearGradient id="title_gloss" x1="0" y1="0" x2="0" y2="0.5">
-      <stop offset="0%" stop-color="rgba(255,255,255,0.7)" />
-      <stop offset="50%" stop-color="rgba(255,255,255,0)" />
+    <linearGradient id="title_gloss" x1="0" y1="0" x2="0" y2="0.6">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.85)" />
+      <stop offset="60%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
-    <rect x="0" y="0" width="{{ title_width }}" height="10" fill="url(#title_gloss)" />
+    <rect x="0" y="0" width="{{ title_width }}" height="12" fill="url(#title_gloss)" clip-path="url(#clip)" />
 
     <!-- Shadow for title -->
-    <linearGradient id="title_shadow" x1="0" y1="0.5" x2="0" y2="1">
+    <linearGradient id="title_shadow" x1="0" y1="0.6" x2="0" y2="1">
       <stop offset="0%" stop-color="rgba(0,0,0,0)" />
-      <stop offset="100%" stop-color="rgba(0,0,0,0.3)" />
+      <stop offset="100%" stop-color="rgba(0,0,0,0.4)" />
     </linearGradient>
-    <rect x="0" y="10" width="{{ title_width }}" height="10" fill="url(#title_shadow)" />
+    <rect x="0" y="12" width="{{ title_width }}" height="8" fill="url(#title_shadow)" clip-path="url(#clip)" />
 
     <!-- Gloss for progress bar -->
-    <linearGradient id="progress_gloss" x1="0" y1="0" x2="0" y2="0.5">
-      <stop offset="0%" stop-color="rgba(255,255,255,0.7)" />
-      <stop offset="50%" stop-color="rgba(255,255,255,0)" />
+    <linearGradient id="progress_gloss" x1="0" y1="0" x2="0" y2="0.6">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.85)" />
+      <stop offset="60%" stop-color="rgba(255,255,255,0)" />
     </linearGradient>
-    <rect x="{{ title_width }}" y="0" width="{{ progress_width }}" height="10" fill="url(#progress_gloss)" />
+    <rect x="{{ title_width }}" y="0" width="{{ progress_width }}" height="12" fill="url(#progress_gloss)" clip-path="url(#clip)" />
 
     <!-- Shadow for progress bar -->
-    <linearGradient id="progress_shadow" x1="0" y1="0.5" x2="0" y2="1">
+    <linearGradient id="progress_shadow" x1="0" y1="0.6" x2="0" y2="1">
       <stop offset="0%" stop-color="rgba(0,0,0,0)" />
-      <stop offset="100%" stop-color="rgba(0,0,0,0.3)" />
+      <stop offset="100%" stop-color="rgba(0,0,0,0.2)" />
     </linearGradient>
-    <rect x="{{ title_width }}" y="10" width="{{ progress_width }}" height="10" fill="url(#progress_shadow)" />
+    <rect x="{{ title_width }}" y="9" width="{{ progress_width }}" height="11" fill="url(#progress_shadow)" clip-path="url(#clip)" />
   {% endif %}
 
   {% if title %}

--- a/templates/progress.svg
+++ b/templates/progress.svg
@@ -13,6 +13,36 @@
   {% endif %}
   <rect rx="{{ border_radius }}" width="{{ title_width + progress_width }}" height="20" fill="url(#a)" />
 
+  {% if gloss %}
+    <!-- Gloss for title -->
+    <linearGradient id="title_gloss" x1="0" y1="0" x2="0" y2="0.5">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.7)" />
+      <stop offset="50%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+    <rect x="0" y="0" width="{{ title_width }}" height="10" fill="url(#title_gloss)" />
+
+    <!-- Shadow for title -->
+    <linearGradient id="title_shadow" x1="0" y1="0.5" x2="0" y2="1">
+      <stop offset="0%" stop-color="rgba(0,0,0,0)" />
+      <stop offset="100%" stop-color="rgba(0,0,0,0.3)" />
+    </linearGradient>
+    <rect x="0" y="10" width="{{ title_width }}" height="10" fill="url(#title_shadow)" />
+
+    <!-- Gloss for progress bar -->
+    <linearGradient id="progress_gloss" x1="0" y1="0" x2="0" y2="0.5">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.7)" />
+      <stop offset="50%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+    <rect x="{{ title_width }}" y="0" width="{{ progress_width }}" height="10" fill="url(#progress_gloss)" />
+
+    <!-- Shadow for progress bar -->
+    <linearGradient id="progress_shadow" x1="0" y1="0.5" x2="0" y2="1">
+      <stop offset="0%" stop-color="rgba(0,0,0,0)" />
+      <stop offset="100%" stop-color="rgba(0,0,0,0.3)" />
+    </linearGradient>
+    <rect x="{{ title_width }}" y="10" width="{{ progress_width }}" height="10" fill="url(#progress_shadow)" />
+  {% endif %}
+
   {% if title %}
     <g fill="#{{ progress_number_color }}" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
       {% if show_shadow %}


### PR DESCRIPTION
Closes #33 

## 📑 Description
This adds the plastic style as requested.

- [ ] Not Completed
- [x] Completed

## ✅ Checks
<!-- Make sure your pr passes the CI checks and check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [x] No

## ℹ Additional Information
The example given to make this style was this:
![image](https://github.com/user-attachments/assets/b9840064-b5b6-49df-93dd-b29395500574)

The previous default style looks like this:
![example_default](https://github.com/user-attachments/assets/e86ecff7-b40a-42ce-9ec9-00cb389172e4)

The new plastic style looks like this:
![example](https://github.com/user-attachments/assets/61888fd0-0f34-4a42-9fb0-9e8debf06d6f)

I've tried to keep the same feel as the default one but with the plastic style, please let me know how I did! 🙂


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded documentation for the dynamic progress bar service, including a new style option: `plastic`.
	- Added examples demonstrating the usage of the `plastic` style and other configuration parameters.
  
- **Documentation**
	- Improved readability and consistency in the `README.md` formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->